### PR TITLE
Adding podspec file

### DIFF
--- a/RadarKit.podspec
+++ b/RadarKit.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+    s.name          = "RadarKit"
+    s.version       = "0.1.0"
+    s.summary       = "A Cedexis Radar client for iOS."
+    s.homepage      = "https://github.com/cedexis/radarkit"
+    s.license       = "MIT"
+    s.author        = "Jacob Wan"
+    s.source        = { :git => "https://github.com/cedexis/RadarKit.git", :tag => s.version.to_s }
+
+    s.platform      = :ios, '7.0'
+    s.requires_arc  = true
+    s.frameworks    = ['Foundation']
+
+    s.source_files  = "RadarKit/*.{h,m}"
+end


### PR DESCRIPTION
Adds a basic pod spec so that others can use this library via CocoaPods.

You might want to edit the `author` field in order to have an email address which would look something like this...

```
s.author    = {"Jacob Wan" => "email goes here" }
```

Also, you will need to actually push a tag of `0.1.0` in order for this to work. If you've never pushed a CocoaPod before, you should follow the guide [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html)

After you've tagged your version, you can run `pod spec lint` in your repo to verify that the spec passes validation. 

Should resolve https://github.com/cedexis/RadarKit/issues/1
